### PR TITLE
Add GoReleaser config to generate SBOM

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -54,6 +54,16 @@ archives:
       - goos: windows
         format: zip
 
+sboms:
+- documents:
+  - "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}.json"
+  artifacts: binary
+  cmd: cyclonedx-gomod
+  args: ["bin", "-json", "-output", "$document", "$artifact"]
+  env:
+  - GOARCH={{ .Arch }}
+  - GOOS={{ .Os }}
+
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
